### PR TITLE
Update projectile impact API usage for NeoForge 21.5.66

### DIFF
--- a/neoforge/src/main/java/com/yyz/enchantinnovation/neoforge/NeoForgeEvents.java
+++ b/neoforge/src/main/java/com/yyz/enchantinnovation/neoforge/NeoForgeEvents.java
@@ -43,8 +43,8 @@ public class NeoForgeEvents {
 
     @SubscribeEvent
     public static void onArrowHit(ProjectileImpactEvent.Arrow event) {
-        if (event.getRayTraceResult().getType() == net.minecraft.world.phys.HitResult.Type.ENTITY) {
-            if (event.getArrow().getOwner() instanceof Player player) {
+        if (event.getHitResult().getType() == net.minecraft.world.phys.HitResult.Type.ENTITY) {
+            if (event.getProjectile().getOwner() instanceof Player player) {
                 ItemStack bow = player.getMainHandItem();
                 if (bow.getItem() instanceof BowItem) {
                     EnchantmentUtils.addExp(bow, 10);


### PR DESCRIPTION
## Summary
- fix `ProjectileImpactEvent` usage after API changes in NeoForge 21.5.66

## Testing
- `./gradlew build` *(fails: environment lacks required setup)*

------
https://chatgpt.com/codex/tasks/task_e_68431ef45ac4832e88ee0b387f16f55a