### PR TITLE
Remove redundant ItemStack field

### DIFF
--- a/common/src/main/java/com/yyz/enchantinnovation/mixin/ItemStackMixin.java
+++ b/common/src/main/java/com/yyz/enchantinnovation/mixin/ItemStackMixin.java
@@ -12,7 +12,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.ArmorItem;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -23,11 +22,10 @@ import java.util.List;
 @Mixin(ItemStack.class)
 public class ItemStackMixin {
 
-    @Unique
-    ItemStack stack = (ItemStack) (Object) this;
 
     @Inject(method = "getTooltipLines", at = @At("RETURN"))
     private void injectGetTooltip(Item.TooltipContext tooltipContext, Player player, TooltipFlag tooltipFlag, CallbackInfoReturnable<List<Component>> cir) {
+        ItemStack stack = (ItemStack)(Object)this;
         if (!stack.isDamageableItem()) return;
 
         int exp = stack.getOrDefault(EnchantInnovationPlatform.getExp(),0);
@@ -41,6 +39,7 @@ public class ItemStackMixin {
     @Inject(method = "hurtAndBreak(ILnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;)V", at = @At("RETURN"))
     private void injectDamage(int i, LivingEntity livingEntity, EquipmentSlot equipmentSlot, CallbackInfo ci) {
         int exp = i;
+        ItemStack stack = (ItemStack)(Object)this;
         Item item = stack.getItem();
 
         if (item instanceof ArmorItem) {


### PR DESCRIPTION
## Summary
- drop stored `ItemStack` reference from `ItemStackMixin`
- cast `this` to `ItemStack` directly in injected methods

## Testing
- `./gradlew build` *(fails: waiting for Gradle cache lock)*

------
https://chatgpt.com/codex/tasks/task_e_68431ef4b5d0832ebf8da014b69e1502